### PR TITLE
Missing properties in wordpress-openstack.yml

### DIFF
--- a/wordpress-openstack.yml
+++ b/wordpress-openstack.yml
@@ -105,3 +105,7 @@ properties:
     secure_auth_salt: random key
     logged_in_salt: random key
     nonce_salt: random key
+
+  nginx:
+      workers: 1
+


### PR DESCRIPTION
```
root@inception:/var/vcap/releases/bosh-sample-release# bosh deploy
Current deployment is /var/vcap/releases/bosh-sample-release/wordpress-openstack.yml
Getting deployment properties from director...
Compiling deployment manifest...
Please review all changes carefully
Deploying `wordpress-openstack.yml' to `microbosh-openstack' (type 'yes' to continue): yes

Director task 4

Preparing deployment
  binding deployment (00:00:00)                                                                     
  binding releases (00:00:00)                                                                       
  binding existing deployment (00:00:00)                                                            
  binding resource pools (00:00:00)                                                                 
  binding stemcells (00:00:00)                                                                      
  binding templates (00:00:00)                                                                      
  binding properties (00:00:00)                                                                     
  binding unallocated VMs (00:00:00)                                                                
  binding instance networks (00:00:00)                                                              
Done                    9/9 00:00:00                                                                

Preparing package compilation
  finding packages to compile (00:00:00)                                                            
Done                    1/1 00:00:00                                                                

Preparing DNS
  binding DNS (00:00:01)                                                                            
Done                    1/1 00:00:01                                                                

Creating bound missing VMs
  common/0 (00:02:39)                                      
  common/3 (00:02:57)                                                                               
  common/2 (00:03:02)                                                                               
  common/1 (00:03:13)                                                                               
Done                    4/4 00:03:13                                                                

Binding instance VMs
  nfs/0 (00:00:01)                                                                                  
  wordpress/0 (00:00:01)                                                                            
  nginx/0 (00:00:01)                                                                                
  mysql/0 (00:00:01)                                                                                
Done                    4/4 00:00:01                                                                

Preparing configuration
  binding configuration: Error filling in template `nginx.conf.erb' for `nginx/0' (line 2: undefined method `workers' for nil:NilClass) (00:00:00)
Error                   1/1 00:00:00                                                                

Error 80006: Error filling in template `nginx.conf.erb' for `nginx/0' (line 2: undefined method `workers' for nil:NilClass)

Task 4 error
```
